### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ PAM module providing TACACS+ authentication, authorization, and accounting for V
 ## Build / test / run
 
 ```sh
-./auto.sh                 # autoreconf + ./configure
+./auto.sh                 # autoreconf (generates ./configure)
+./configure
 make
 dpkg-buildpackage -us -uc
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+## Project purpose
+
+PAM module providing TACACS+ authentication, authorization, and accounting for VyOS logins, plus the `libtac` TACACS+ protocol library and the `tacc` CLI client. Pairs with `libnss-tacplus` (NSS lookups) and `libtacplus-map` (user mapping) to deliver TACACS+ login on VyOS.
+
+## Tech stack
+
+- C, GNU autotools (`configure.ac`, `Makefile.am`, `auto.sh`).
+- Debian packaging in `debian/` (debhelper >= 9, `libpam-dev`, `dh-autoreconf`, `autoconf-archive`, `libaudit-dev`).
+- Builds Debian packages: `libpam-tacplus`, `libpam-tacplus-dev`, `libtac2`, `libtac2-bin`, `libtac-dev`.
+- License: GPL-2.0 (per `COPYING`).
+
+## Build / test / run
+
+```sh
+./auto.sh                 # autoreconf + ./configure
+make
+dpkg-buildpackage -us -uc
+```
+
+`tacc` is a small CLI client useful for manual testing (`tacc.1` man page). No bundled unit tests; Coverity scan badge in README references upstream.
+
+## Repository layout
+
+- `pam_tacplus.c`, `pam_tacplus.h`, `support.c/h` — PAM module.
+- `libtac/` — protocol library (produces `libtac2`).
+- `tacc.c`, `tacc.1` — CLI client.
+- `tacplus_servers`, `tacplus_servers.5`, `Pam.d.common-example`, `sample.pam` — config + examples.
+- `debian/`, `pam_tacplus.spec.in` — packaging.
+
+## Cross-repo context
+
+Authentication building block of the VyOS image. Provides the `libtac` library that `libnss-tacplus` links against, and the PAM module that `libtacplus-map` complements for `/etc/passwd`-less TACACS+ logins. Built via `VyOS-Networks/vyos-build-packages`; consumed by `vyos/vyos-build`.
+
+## Conventions
+
+- Default branch `master`. LTS branches when needed.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Treat as upstream-vendored: minimise diffs against the upstream `pam_tacplus`.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/libpam-tacplus`. Canonical side is here. Note that the VyOS-Networks side has its `git-actions` branch configured as default (audit observation §8.2 of relations doc) — that's not the canonical state.
+
+## Notes for future contributors
+
+- The `libtac/` subdirectory is the TACACS+ protocol library and is shipped as a separately versioned `libtac2` Debian package — bump the soname carefully.
+- README is upstream's; VyOS-specific behaviour is encoded only by the build flags and patches applied here.
+
+---
+
+This file is mirrored on Confluence: [`vyos/libpam-tacplus`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889495). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,3 @@ Mirror twin: `VyOS-Networks/libpam-tacplus`. Canonical side is here. Note that t
 
 - The `libtac/` subdirectory is the TACACS+ protocol library and is shipped as a separately versioned `libtac2` Debian package — bump the soname carefully.
 - README is upstream's; VyOS-specific behaviour is encoded only by the build flags and patches applied here.
-
----
-
-This file is mirrored on Confluence: [`vyos/libpam-tacplus`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889495). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
