### PR TITLE
T8943: migrate branch refs master->rolling (rollout 1c)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [master]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs master->rolling; action-ref to vyos/.github -> production; HIGH-producer pins already swept. Tracking: T8943