### PR TITLE
T8966: add legacy-label escape to invalid-task-id rule (commit check exempt)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -19,7 +19,9 @@ pull_request_rules:
       - 'author!=vyosbot'
       - or:
           - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
-          - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+          - and:
+              - 'label!=legacy'
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
     actions:
       label:
         toggle:


### PR DESCRIPTION
Adds a maintainer-controlled `legacy` label escape to the per-repo T-ID rule (toggles `invalid-task-id`). The PR **title** check stays enforced for every PR; the **per-commit** check is exempted when a PR carries the `legacy` label — an escape hatch for grandfathered PRs whose commit history cannot be rewritten (repos that squash-merge and block force-push). Pilot verified on vyos/vyos.vyos. Change-management: IS-539. Tracked under T8966.

🤖 Generated by [robots](https://vyos.io)